### PR TITLE
Bump version to 4.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` config to `enonic-gradle.yml` listing `master` and `3.x` so pushes to either branch are recognized as release-branch builds by `enonic/release-tools/build-and-publish`.
- `gradle.properties` is already at `version=4.0.0-SNAPSHOT` (no change required on master).

Branched off the post-release SNAPSHOT commit `7609672` to create the `3.x` maintenance branch in parallel; companion PR against `3.x` adds the same workflow edit there.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, push to `master` is classified as a release-branch build by `enonic/release-tools/build-and-publish@master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)