### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` config to `enonic-gradle.yml` listing `master` and `3.x` so pushes to `3.x` are recognized as release-branch builds by `enonic/release-tools/build-and-publish` (the action reads `releaseBranch:` from the branch's own workflow file).
- No version bump on this branch — `gradle.properties` is already at `3.0.2-SNAPSHOT` from the post-release SNAPSHOT commit (`7609672`).

Companion PR against `master` adds the same workflow edit there: #35.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, push to `3.x` is classified as a release-branch build by `enonic/release-tools/build-and-publish@master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)