### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,3 @@
+[versions]
+
+[libraries]


### PR DESCRIPTION
## Summary

Introduce `gradle/libs.versions.toml` so this repo aligns with the rest of the IdeaProjects tree (`app-features`, `lib-explorer`, `app-disqus`, …). Bulk dependency bumps can now target one consistent location.

## What changed

- New file `gradle/libs.versions.toml`.
- `build.gradle` is untouched.

## Inventory

Running the inline-version inventory against `build.gradle`:

```
implementation xplibs.portal
```

That's the only dependency, and `xplibs.*` accessors are explicitly excluded from the catalog per the migration spec (they come from the XP gradle plugin). There are no `name:name:version` strings to migrate. `xpVersion` stays in `gradle.properties` as required.

The `com.enonic.defaults` plugin version (`2.1.6`) is left inline — promoting a single plugin to a `[plugins]` block doesn't earn its keep here, matching the pattern in `app-disqus` and `app-facebook-pixel`.

## Catalog content

```toml
[versions]

[libraries]
```

Section headers only — placeholder for future pinned dependencies. The file is intentionally empty today; its value is the well-known path for automation.

## Conventions adopted

- Hyphen-separated lowercase keys (when entries are added later).
- `[versions]` and `[libraries]` sorted alphabetically.
- `xpVersion` left in `gradle.properties`.
- No `xplibs.*` migration.

## Verification

- `./gradlew build --refresh-dependencies` → `BUILD SUCCESSFUL`.
- `./gradlew dependencies --configuration runtimeClasspath` → identical tree (`com.enonic.xp:lib-portal:8.0.0-B4` and its transitives).
- `./gradlew build --warning-mode all` → no warnings on the empty catalog.

## Test plan

- [x] `./gradlew build --refresh-dependencies` passes.
- [x] Runtime classpath unchanged vs. pre-migration.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)